### PR TITLE
JSON-LD Refactor

### DIFF
--- a/lib/blog_post_to_json_ld.rb
+++ b/lib/blog_post_to_json_ld.rb
@@ -49,7 +49,7 @@ def process_html_to_ld_json(html_file)
 
   write_json_ld_to_file(html_file, FAQ_SCHEMA.merge(mainEntity: faqs)) unless faqs.empty?
 
-  prompt.say(" [✔] Processed #{html_file}")
+  prompt.say(" [#{Pastel.new.green("✔")}] Processed #{html_file}")
 end
 
 def prompt

--- a/lib/blog_post_to_json_ld.rb
+++ b/lib/blog_post_to_json_ld.rb
@@ -8,6 +8,7 @@ require "json"
 require_relative "services/open_ai_client"
 
 FAQ_SCHEMA = {"@context": "https://schema.org", "@type": "FAQPage"}
+PROJECT_ROOT = File.expand_path("..", __dir__)
 
 def build_faq_structure(faq, reword_answer: false)
   answer = faq.next_element.text.strip
@@ -31,7 +32,7 @@ def extract_faqs_from_html(html_file)
 end
 
 def html_files
-  @html_file ||= Dir.glob(File.join("posts", "*.html"))
+  @html_file ||= Dir.glob(File.join("#{PROJECT_ROOT}/posts/", "*.html"))
 end
 
 def make_readable(text)
@@ -60,7 +61,7 @@ def spinner
 end
 
 def write_json_ld_to_file(filename, json_ld)
-  Dir.mkdir("json-ld") unless Dir.exist?("json-ld")
+  Dir.mkdir("#{PROJECT_ROOT}/json-ld") unless Dir.exist?("#{PROJECT_ROOT}/json-ld")
   File.write(filename.gsub(".html", ".json").gsub("posts/", "json-ld/"), JSON.pretty_generate(json_ld))
 end
 

--- a/lib/services/cli_service.rb
+++ b/lib/services/cli_service.rb
@@ -4,6 +4,8 @@ require "tty-spinner"
 require_relative "service"
 
 class CLIService < Service
+  PROJECT_ROOT = File.expand_path("../..", __dir__)
+
   private
 
   def fetch_url(url)

--- a/lib/services/json_transformer.rb
+++ b/lib/services/json_transformer.rb
@@ -1,0 +1,81 @@
+require "json"
+require "nokogiri"
+require_relative "cli_service"
+require_relative "open_ai_client"
+
+class JSONTransformer < CLIService
+  option :html_path, type: Dry::Types["strict.string"]
+  option :reword_answer, optional: true, type: Dry::Types["strict.string"]
+
+  FAQ_SCHEMA = {"@context": "https://schema.org", "@type": "FAQPage"}
+
+  def call
+    prompt.say("Processing files in #{@html_path}...")
+    Success.new(transform_json)
+  rescue => e
+    log_with_failure(e.message)
+  end
+
+  private
+
+  def build_faq_structure(faq)
+    answer = faq.next_element.text.strip
+    answer = make_readable(answer) if call_openai?
+    {
+      "@type": "Question",
+      name: faq.text.strip,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer
+      }
+    }
+  end
+
+  def call_openai?
+    @reword_answer != Dry::Initializer::UNDEFINED
+  end
+
+  def html_files
+    @html_file ||= Dir.glob(File.join("#{PROJECT_ROOT}/#{@html_path}/", "*.html"))
+  end
+
+  def make_readable(text)
+    spinner.auto_spin
+    readable_text = OpenAIClient.call(message: "Simplify the following text: #{text}").value!
+    spinner.success("Done!")
+    prompt.say(" - Old: #{text}", color: :red)
+    prompt.say(" - New: #{readable_text}", color: :green)
+    readable_text
+  end
+
+  def process_html_to_ld_json(html_file)
+    save_to_disk(
+      rename_html_to_json(html_file),
+      transform_html_to_json_faq(html_file),
+      "#{PROJECT_ROOT}/json-ld"
+    )
+
+    prompt.say(" [#{Pastel.new.green("✔")}] Processed #{html_file}")
+  end
+
+  def rename_html_to_json(filename)
+    filename.gsub(".html", ".json").gsub("posts/", "json-ld/")
+  end
+
+  def transform_json
+    html_files.each do |html_file|
+      process_html_to_ld_json(html_file)
+    end
+    prompt.say("✔ Done!", color: :green)
+  end
+
+  def transform_html_to_json_faq(html_file)
+    document = File.open(html_file) { |file| Nokogiri::HTML(file) }
+
+    faqs = document.css("h2").map do |faq|
+      build_faq_structure(faq) if faq.next_element
+    end
+
+    JSON.pretty_generate(FAQ_SCHEMA.merge(mainEntity: faqs))
+  end
+end

--- a/spec/fixtures/post_1.html
+++ b/spec/fixtures/post_1.html
@@ -3,6 +3,8 @@
 <body>
   <h1>Post 1</h1>
   <p>Post copy.</p>
+  <h2>Question</h2>
+  <p>Answer</p>
 </body>
 
 </html>

--- a/spec/fixtures/post_1.json
+++ b/spec/fixtures/post_1.json
@@ -1,0 +1,14 @@
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Question",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Answer"
+      }
+    }
+  ]
+}

--- a/spec/lib/services/json_transformer_spec.rb
+++ b/spec/lib/services/json_transformer_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require_relative "../../../lib/services/json_transformer"
+
+RSpec.describe(JSONTransformer) do
+  let(:html_file_name) { "post_1.html" }
+  let(:json_file_path) { "#{File.expand_path("../../..", __dir__)}/json-ld/post_1.json" }
+  let(:mock_file) { instance_double(File, write: true) }
+  let(:mock_spinner) { instance_double(TTY::Spinner, run: true) }
+
+  describe("#call") do
+    it "returns a success monad" do
+      response = described_class.call(html_path: "html")
+
+      expect(response.success?).to be(true)
+    end
+
+    it "writes JSON-LD files to output_path" do
+      allow(Dir).to receive(:glob).and_return([html_file_name])
+      allow(File).to receive(:write).and_return(mock_file)
+      allow(File).to receive(:open).and_return(blog_post)
+
+      described_class.call(html_path: "html")
+
+      expect(File).to have_received(:write).with(json_file_path, json_result)
+    end
+  end
+
+  def blog_post
+    @html ||= Nokogiri::HTML(File.read("spec/fixtures/post_1.html"))
+  end
+
+  def json_result
+    @json_result ||= File.read("spec/fixtures/post_1.json").chomp
+  end
+end


### PR DESCRIPTION
This PR creates a service object to turn `HTML` => `JSON-LD`. The design assumes that FAQs can be created by using `H2`s as the question and the following `p` tag as the answer.

It also does some OpenAI business that will likely be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a feature to transform FAQ content in HTML files into JSON-LD format.

- **Enhancements**
  - Improved file location handling with a new `PROJECT_ROOT` constant for directory operations.
  - Enhanced `SiteScraper` functionality with new methods for HTML content handling and file management.

- **Bug Fixes**
  - Fixed directory path issues in HTML file processing.

- **Documentation**
  - Added new HTML fixtures for testing, including FAQ question and answer elements.

- **Tests**
  - Implemented a new test suite for the `JSONTransformer` class to ensure accurate HTML to JSON-LD transformation. 

- **Refactor**
  - Refactored code to utilize constants for path management and private methods for cleaner code organization.

- **Style**
  - No user-visible style changes reported.

- **Chores**
  - Added development tools for debugging purposes.

- **Revert**
  - No reverts in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->